### PR TITLE
Formatting changes & compatibility patch for Python 3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Jan Arnold
+Copyright (c) 2016-2017 Jan Arnold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,58 +1,38 @@
-# README #
 
-[NetData](https://github.com/firehol/netdata/) plugin that polls active users and bandwidth from TeamSpeak 3 servers.
+# Teamspeak 3 netdata Plugin #
+
+This is a [netdata](https://github.com/firehol/netdata/) plugin that polls active
+users and bandwidth from TeamSpeak 3 servers.
 
 ![TS3 plugin screenshot](http://semper.space/netdata_ts3/screenshot01.png "Netdata TS3 plugin")
 
-### Installation ###
+## Installation ##
 
-With default NetData installation copy the ts3.chart.py script to `/usr/libexec/netdata/python.d/` and the ts3.conf config file to `/etc/netdata/python.d/`.
+With your default netdata installation copy the ts3.chart.py script to
+`/usr/libexec/netdata/python.d/` and the ts3.conf config file to
+`/etc/netdata/python.d/`. The location of these directories may vary depending
+on your distribution. Read your given release of netdata for more information.
 
-Edit the config file to set the TeamSpeak Server Query user and password.
-If not already set, connect to your TeamSpeak server with the TeamSpeak client and go to menu 'Extras' -> 'ServerQuery Login' and set a user and password.
+Edit the config file to set the TeamSpeak Server Query user and password. If not
+already set, connect to your TeamSpeak server with the TeamSpeak client and go
+to menu 'Extras' -> 'ServerQuery Login' and set a user and password.
 
-Then restart NetData to activate the plugin.
+Restart netdata to activate the plugin after you have made these changes.
 
-To disable the ts3 plugin, edit `/etc/netdata/python.d.conf` and add `ts3: no`.
+To disable the Teamspeak 3 plugin, edit `/etc/netdata/python.d.conf` and add
+`ts3: no`.
 
+## Version History ##
 
-### License ###
+- v0.7 - Major readability and formatting changes as well as a compatibility fix for Python 3.6.2
+- v0.6 - Bugfix: Default netdata socket service raised an error when decoding non ASCII characters
+- v0.5 - Added packet loss graph and file transfer bandwidth
+- v0.4 - Added bandwidth graph
+- v0.3 - Cleanup and config implementation (Special thanks to @paulfantom)
+- v0.2 - Rewrote plugin to use Netdata's SocketService
+- v0.1 - Initial release
 
-The MIT License (MIT)
-Copyright (c) 2016 Jan Arnold
+## License ##
 
-	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-	documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-	the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-	and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in all copies or substantial portions
-	of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-	TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-	THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-	CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-	DEALINGS IN THE SOFTWARE.
-
-
-### Version ###
-
-v0.6 - bugfix: default netdata socket service raised an error when decoding non ascii characters
-
-v0.5 - added packet loss graph and file transfer bandwidth
-
-v0.4 - added bandwidth graph
-
-v0.3 - cleanup and config implementation - thx for the help @paulfantom
-
-v0.2 - rewrote plugin to use Netdata's SocketService
-
-v0.1 - initial release
-
-
-
-### Who do I talk to? ###
-
-* Repo owner or admin
-* Other community or team contact
+This repository is released under the MIT license. For more information please
+refer to [LICENSE](https://github.com/catlinman/netdata_ts3_plugin/blob/master/LICENSE)

--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -262,6 +262,7 @@ class Service(SocketService):
         if regex == []:
             self.error("Information could not be extracted")
             return None
+
         try:
             # Clients and query clients connected.
             connected_users = int(regex[0][0]) - int(regex[1][1])

--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -1,252 +1,293 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 """
 NetData plugin for active users on TeamSpeak 3 servers.
-Please set user and password for your TeamSpeakQuery login in the ts3.conf.
-
+Please set user and password for your TeamSpeakQuery login in the 'ts3.conf'.
 
 The MIT License (MIT)
-Copyright (c) 2016 Jan Arnold
+Copyright (c) 2016-2017 Jan Arnold
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
-and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions
-of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# @Title			: ts3.chart
-# @Project			:
-# @Description		: NetData plugin for active users on TeamSpeak 3 servers
-# @Author			: Jan Arnold
-# @Email			: jan.arnold (at) coraxx.net
-# @Copyright		: Copyright (C) 2016  Jan Arnold
-# @License			: MIT
-# @Credits			:
-# @Maintainer		: Jan Arnold
-# @Date				: 2016/08/15
-# @Version			: 0.6
-# @Status			: stable
-# @Usage			: automatically processed by netdata
-# @Notes			: With default NetData installation put this file under
-#					: /usr/libexec/netdata/python.d/
-#					: and the config file under /etc/netdata/python.d/
-# @Python_version	: 2.7.11
+# @Title            : ts3.chart
+# @Description      : NetData plugin for active users on TeamSpeak 3 servers
+# @Author           : Jan Arnold
+# @Email            : jan.arnold (at) coraxx.net
+# @Copyright        : Copyright (C) 2016-2017 Jan Arnold
+# @License          : MIT
+# @Maintainer       : Jan Arnold
+# @Date             : 2017/09/12
+# @Version          : 0.7
+# @Status           : stable
+# @Usage            : Automatically processed by netdata
+# @Notes            : With default NetData installation put this file under
+#                   : /usr/libexec/netdata/python.d/ and the config file under
+#                   : /etc/netdata/python.d/
+# @Python_version   : 3.6.2
 """
-# ======================================================================================================================
+
 import os
 import re
 import select
+
 from base import SocketService
 
-## Plugin settings
+# Basic plugin settings for netdata.
 update_every = 1
 priority = 60000
 retries = 10
 
-ORDER = ['users','bandwidth_total','bandwidth_filetransfer','packetloss']
+ORDER = ['users', 'bandwidth_total', 'bandwidth_filetransfer', 'packetloss']
 
 CHARTS = {
-	'users': {
-		'options': [None, 'Users online', 'users', 'Users', 'ts3.connected_user', 'line'],
-		'lines': [
-			['connected_users', 'online', 'absolute']
-		]},
-	'bandwidth_total': {
-		'options': [None, 'Bandwidth total', 'kb/s', 'Bandwidth', 'ts3.bandwidth_total', 'area'],
-		'lines': [
-			['bandwidth_total_received', 'received', 'absolute', 1, 1000],
-			['bandwidth_total_sent', 'sent', 'absolute', -1, 1000]
-		]},
-	'bandwidth_filetransfer': {
-		'options': [None, 'Bandwidth filetransfer', 'kb/s', 'Bandwidth', 'ts3.bandwidth_filetransfer', 'area'],
-		'lines': [
-			['bandwidth_filetransfer_received', 'received', 'absolute', 1, 1000],
-			['bandwidth_filetransfer_sent', 'sent', 'absolute', -1, 1000]
-		]},
-	'packetloss': {
-		'options': [None, 'Average data packet loss', 'packets', 'Packet Loss', 'ts3.packetloss', 'line'],
-		'lines': [
-			['packetloss_speech', 'speech', 'absolute'],
-			['packetloss_keepalive', 'keepalive', 'absolute'],
-			['packetloss_control', 'control', 'absolute'],
-			['packetloss_total', 'total', 'absolute']
-		]}
+    'users': {
+        'options': [None, 'Users online', 'users', 'Users', 'ts3.connected_user', 'line'],
+        'lines': [
+            ['connected_users', 'online', 'absolute']
+        ]
+    },
+    'bandwidth_total': {
+        'options': [None, 'Bandwidth total', 'kb/s', 'Bandwidth', 'ts3.bandwidth_total', 'area'],
+        'lines': [
+            ['bandwidth_total_received', 'received', 'absolute', 1, 1000],
+            ['bandwidth_total_sent', 'sent', 'absolute', -1, 1000]
+        ]
+    },
+    'bandwidth_filetransfer': {
+        'options': [None, 'Bandwidth filetransfer', 'kb/s', 'Bandwidth', 'ts3.bandwidth_filetransfer', 'area'],
+        'lines': [
+            ['bandwidth_filetransfer_received', 'received', 'absolute', 1, 1000],
+            ['bandwidth_filetransfer_sent', 'sent', 'absolute', -1, 1000]
+        ]
+    },
+    'packetloss': {
+        'options': [None, 'Average data packet loss', 'packets', 'Packet Loss', 'ts3.packetloss', 'line'],
+        'lines': [
+            ['packetloss_speech', 'speech', 'absolute'],
+            ['packetloss_keepalive', 'keepalive', 'absolute'],
+            ['packetloss_control', 'control', 'absolute'],
+            ['packetloss_total', 'total', 'absolute']
+        ]
+    }
 }
 
 
 class Service(SocketService):
-	def __init__(self, configuration=None, name=None):
-		SocketService.__init__(self, configuration=configuration, name=name)
+    def __init__(self, configuration=None, name=None):
+        SocketService.__init__(self, configuration=configuration, name=name)
 
-		## TeamSpeak Server settings
-		self.host = "localhost"
-		self.port = "10011"
+        # Default TeamSpeak Server connection settings.
+        self.host = "localhost"
+        self.port = "10011"
 
-		## Socket settings
-		self.unix_socket = None
-		self._keep_alive = True
-		self.request = "serverinfo\n"
+        # Connection socket settings.
+        self.unix_socket = None
+        self._keep_alive = True
+        self.request = "serverinfo\n"
 
-		# Chart
-		self.order = ORDER
-		self.definitions = CHARTS
+        # Chart information handled by netdata.
+        self.name = "Teamspeak 3 Server"
+        self.order = ORDER
+        self.definitions = CHARTS
 
-	def check(self):
-		"""
-		Parse configuration and check if local Teamspeak server is running
-		:return: boolean
-		"""
-		self._parse_config()
+    def check(self):
+        """
+        Parse configuration and check if local Teamspeak server is running
+        :return: boolean
+        """
+        self._parse_config()
 
-		try:
-			self.user = self.configuration['user']
-			if self.user == '': raise KeyError
-		except KeyError:
-			self.error(
-				"Please specify a TeamSpeak Server query user inside the ts3.conf!", "Disabling plugin...")
-			return False
-		try:
-			self.passwd = self.configuration['pass']
-			if self.passwd == '': raise KeyError
-		except KeyError:
-			self.error(
-				"Please specify a TeamSpeak Server query password inside the ts3.conf!", "Disabling plugin...")
-			return False
-		try:
-			self.sid = self.configuration['sid']
-		except KeyError:
-			self.sid = 1
-			self.debug("No sid specified. Using: '{0}'".format(self.sid))
+        try:
+            self.user = self.configuration['user']
 
-		## Check once if TS3 is running when host is localhost
-		if self.host in ['localhost','127.0.0.1']:
-			TS3_running = False
-			pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
-			for pid in pids:
-				try:
-					if 'ts3server' in open(os.path.join('/proc', pid, 'cmdline'), 'rb').read():
-						TS3_running = True
-						break
-				except IOError:
-					pass
-			if TS3_running is False:
-				self.error("No local TeamSpeak server running. Disabling plugin...")
-				return False
-			else:
-				self.debug("TeamSpeak server process found. Connecting...")
+            if self.user == '':
+                raise KeyError
 
-		return True
+        except KeyError:
+            self.error(
+                "Please specify a TeamSpeak Server query user inside the ts3.conf!", "Disabling plugin...")
 
-	def _send(self):
-		"""
-		Send request.
-		:return: boolean
-		"""
-		# Send request if it is needed
-		if self.request != "".encode():
-			try:
-				self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
-				self._receive()
-				self._sock.send("use sid={0}\n".format(self.sid).encode())
-				self._receive()
-				self._sock.send(self.request)
-			except Exception as e:
-				self._disconnect()
-				self.error(
-					str(e),
-					"used configuration: host:", str(self.host),
-					"port:", str(self.port),
-					"socket:", str(self.unix_socket))
-				return False
-		return True
+            return False
 
-	def _receive(self):
-		"""
-		Receive data from socket
-		:return: str
-		"""
-		data = ""
-		while True:
-			try:
-				ready_to_read, _, in_error = select.select([self._sock], [], [], 5)
-			except Exception as e:
-				self.debug("SELECT", str(e))
-				self._disconnect()
-				break
-			if len(ready_to_read) > 0:
-				buf = self._sock.recv(4096)
-				if len(buf) == 0 or buf is None:  # handle server disconnect
-					break
-				self.debug(str(buf))
-				data += buf.decode("utf-8")
-				if self._check_raw_data(data):
-					break
-			else:
-				self.error("Socket timed out.")
-				self._disconnect()
-				break
+        try:
+            self.passwd = self.configuration['pass']
 
-		return data
+            if self.passwd == '':
+                raise KeyError
 
-	def _get_data(self):
-		"""
-		Format data received from socket
-		:return: dict
-		"""
-		data = {}
-		try:
-			raw = self._get_raw_data()
-		except (ValueError, AttributeError):
-			self.error("no data received")
-			return None
+        except KeyError:
+            self.error(
+                "Please specify a TeamSpeak Server query password inside the ts3.conf!", "Disabling plugin...")
 
-		reg = re.compile(
-			"virtualserver_clientsonline=(\d*)|" +
-			"virtualserver_queryclientsonline=(\d*)|" +
-			"connection_bandwidth_sent_last_second_total=(\d*)|" +
-			"connection_bandwidth_received_last_second_total=(\d*)|" +
-			"connection_filetransfer_bandwidth_sent=(\d*)|" +
-			"connection_filetransfer_bandwidth_received=(\d*)|" +
-			"virtualserver_total_packetloss_speech=(\d*)|" +
-			"virtualserver_total_packetloss_keepalive=(\d*)|" +
-			"virtualserver_total_packetloss_control=(\d*)|" +
-			"virtualserver_total_packetloss_total=(\d*)"
-			)
-		regex = reg.findall(raw)
-		self.debug(str(regex))
-		if regex == []:
-			self.error("Information could not be extracted")
-			return None
-		try:
-			## clients connected - query clients connected
-			connected_users = int(regex[0][0]) - int(regex[1][1])
-			data["connected_users"] = connected_users
-			## bandwidth info from server in bytes/s
-			data["bandwidth_total_sent"] = int(regex[8][2])
-			data["bandwidth_total_received"] = int(regex[9][3])
-			data["bandwidth_filetransfer_sent"] = int(regex[6][4])
-			data["bandwidth_filetransfer_received"] = int(regex[7][5])
-			## The average packet loss
-			data["packetloss_speech"] = float(regex[2][6])
-			data["packetloss_keepalive"] = float(regex[3][7])
-			data["packetloss_control"] = float(regex[4][8])
-			data["packetloss_total"] = float(regex[5][9])
-		except Exception as e:
-			self.error(str(e))
-			return None
+            return False
 
-		return data
+        try:
+            self.sid = self.configuration['sid']
 
-	def _check_raw_data(self, data):
-		if data.endswith("msg=ok\n\r"):
-			return True
-		else:
-			return False
+        except KeyError:
+            self.sid = 1
+            self.debug("No sid specified. Using: '{0}'".format(self.sid))
+
+        # Check once if TS3 is running when host is localhost.
+        if self.host in ['localhost', '127.0.0.1']:
+            TS3_running = False
+
+            pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+
+            for pid in pids:
+                try:
+                    if b'ts3server' in open(os.path.join('/proc', pid, 'cmdline').encode(), 'rb').read():
+                        TS3_running = True
+                        break
+
+                except IOError as e:
+                    self.error(e)
+
+            if TS3_running is False:
+                self.error("No local TeamSpeak server running. Disabling plugin...")
+
+                return False
+
+            else:
+                self.debug("TeamSpeak server process found. Connecting...")
+
+        return True
+
+    def _send(self):
+        """
+        Send request.
+        :return: boolean
+        """
+        # Send request if it is needed
+        if self.request != "".encode():
+            try:
+                self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
+                self._receive()
+                self._sock.send("use sid={0}\n".format(self.sid).encode())
+                self._receive()
+                self._sock.send(self.request)
+
+            except Exception as e:
+                self._disconnect()
+                self.error(
+                    str(e),
+                    "used configuration: host:", str(self.host),
+                    "port:", str(self.port),
+                    "socket:", str(self.unix_socket))
+
+                return False
+
+        return True
+
+    def _receive(self):
+        """
+        Receive data from socket
+        :return: str
+        """
+        data = ""
+
+        while True:
+            try:
+                ready_to_read, _, in_error = select.select([self._sock], [], [], 5)
+            except Exception as e:
+                self.debug("SELECT", str(e))
+                self._disconnect()
+                break
+
+            if len(ready_to_read) > 0:
+                buf = self._sock.recv(4096)
+
+                if len(buf) == 0 or buf is None:  # handle server disconnect
+                    break
+
+                self.debug(str(buf))
+                data += buf.decode("utf-8")
+
+                if self._check_raw_data(data):
+                    break
+            else:
+                self.error("Socket timed out.")
+                self._disconnect()
+
+                break
+
+        return data
+
+    def _get_data(self):
+        """
+        Format data received from socket
+        :return: dict
+        """
+        data = {}
+        try:
+            raw = self._get_raw_data()
+
+        except (ValueError, AttributeError):
+            self.error("No data received.")
+
+            return None
+
+        reg = re.compile(
+            "virtualserver_clientsonline=(\d*)|" +
+            "virtualserver_queryclientsonline=(\d*)|" +
+            "connection_bandwidth_sent_last_second_total=(\d*)|" +
+            "connection_bandwidth_received_last_second_total=(\d*)|" +
+            "connection_filetransfer_bandwidth_sent=(\d*)|" +
+            "connection_filetransfer_bandwidth_received=(\d*)|" +
+            "virtualserver_total_packetloss_speech=(\d*)|" +
+            "virtualserver_total_packetloss_keepalive=(\d*)|" +
+            "virtualserver_total_packetloss_control=(\d*)|" +
+            "virtualserver_total_packetloss_total=(\d*)"
+        )
+
+        regex = reg.findall(raw)
+
+        self.debug(str(regex))
+
+        if regex == []:
+            self.error("Information could not be extracted")
+            return None
+        try:
+            # Clients and query clients connected.
+            connected_users = int(regex[0][0]) - int(regex[1][1])
+            data["connected_users"] = connected_users
+
+            # Bandwidth info from server in bytes/s.
+            data["bandwidth_total_sent"] = int(regex[8][2])
+            data["bandwidth_total_received"] = int(regex[9][3])
+            data["bandwidth_filetransfer_sent"] = int(regex[6][4])
+            data["bandwidth_filetransfer_received"] = int(regex[7][5])
+
+            # The average packet loss.
+            data["packetloss_speech"] = float(regex[2][6])
+            data["packetloss_keepalive"] = float(regex[3][7])
+            data["packetloss_control"] = float(regex[4][8])
+            data["packetloss_total"] = float(regex[5][9])
+
+        except Exception as e:
+            self.error(str(e))
+            return None
+
+        return data
+
+    def _check_raw_data(self, data):
+        if data.endswith("msg=ok\n\r"):
+            return True
+
+        else:
+            return False

--- a/ts3.conf
+++ b/ts3.conf
@@ -7,21 +7,21 @@
 # with multiple virtual servers (TS servers with a license).
 
 local:
-  # update_every: 1
-  # priority: 60000
-  # retries: 10
-  # host: 'localhost'
-  # port: 10011
-  # sid: 1
-  user: ''
-  pass: ''
+    # update_every: 1
+    # priority: 60000
+    # retries: 10
+    # host: 'localhost'
+    # port: 10011
+    # sid: 1
+    user: ''
+    pass: ''
 
 # external:
-  # update_every: 1
-  # priority: 60000
-  # retries: 10
-  # host: '123.456.789.0'
-  # port: 10011
-  # sid: 1
-  # user: ''
-  # pass: ''
+    # update_every: 1
+    # priority: 60000
+    # retries: 10
+    # host: '123.456.789.0'
+    # port: 10011
+    # sid: 1
+    # user: ''
+    # pass: ''


### PR DESCRIPTION
Made major changes to the entire script's code formatting making it a lot easier to read on first time viewing. Enforced some formatting rules that should be apparent to the person editing and as such making maintaining the script a lot easier.

Was prompted to make this change as I am running the newest version of netdata with Python 3.6.2 and encountered an error preventing the chart from displaying. Traced the issue to a string not being converted to bytes when required and patched this bug.

The README.md file have also been reformatted to remove information that isn't required as well as updating some spelling. Removed the license section's actual license to instead point to the LICENSE.md file on the master branch to avoid duplication so to say.

The entire file was also formatted to display much better when viewed on the command line by wrapping longer text segments.