### PR TITLE
Fixed packet loss metric not working & init error can't set attribute "self.name"

### DIFF
--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -176,7 +176,7 @@ class Service(SocketService):
         # Send request if it is needed
         if self.request != "".encode():
             try:
-                self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
+                self._sock.send("whoami\n")
                 self._receive()
                 self._sock.send("use sid={0}\n".format(self.sid).encode())
                 self._receive()
@@ -289,6 +289,8 @@ class Service(SocketService):
     def _check_raw_data(self, data):
         if data.endswith("msg=ok\n\r"):
             return True
-
+        elif "virtualserver_status=unknown" in data: 
+			self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
+			self._receive()
         else:
             return False

--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -76,12 +76,12 @@ CHARTS = {
         ]
     },
     'packetloss': {
-        'options': [None, 'Average data packet loss', 'packets', 'Packet Loss', 'ts3.packetloss', 'line'],
+        'options': [None, 'Average data packet loss', 'packets loss %', 'Packet Loss', 'ts3.packetloss', 'line'],
         'lines': [
-            ['packetloss_speech', 'speech', 'absolute'],
-            ['packetloss_keepalive', 'keepalive', 'absolute'],
-            ['packetloss_control', 'control', 'absolute'],
-            ['packetloss_total', 'total', 'absolute']
+            ['packetloss_speech', 'speech', 'absolute', 1, 100000],
+            ['packetloss_keepalive', 'keepalive', 'absolute', 1, 100000],
+            ['packetloss_control', 'control', 'absolute', 1, 100000],
+            ['packetloss_total', 'total', 'absolute', 1, 100000],
         ]
     }
 }
@@ -249,10 +249,10 @@ class Service(SocketService):
             "connection_bandwidth_received_last_second_total=(\d*)|" +
             "connection_filetransfer_bandwidth_sent=(\d*)|" +
             "connection_filetransfer_bandwidth_received=(\d*)|" +
-            "virtualserver_total_packetloss_speech=(\d*)|" +
-            "virtualserver_total_packetloss_keepalive=(\d*)|" +
-            "virtualserver_total_packetloss_control=(\d*)|" +
-            "virtualserver_total_packetloss_total=(\d*)"
+            "virtualserver_total_packetloss_speech=(\d+\.\d+)|" +
+            "virtualserver_total_packetloss_keepalive=(\d+\.\d+)|" +
+            "virtualserver_total_packetloss_control=(\d+\.\d+)|" +
+            "virtualserver_total_packetloss_total=(\d+\.\d+)"
         )
 
         regex = reg.findall(raw)
@@ -275,11 +275,11 @@ class Service(SocketService):
             data["bandwidth_filetransfer_received"] = int(regex[7][5])
 
             # The average packet loss.
-            data["packetloss_speech"] = float(regex[2][6])
-            data["packetloss_keepalive"] = float(regex[3][7])
-            data["packetloss_control"] = float(regex[4][8])
-            data["packetloss_total"] = float(regex[5][9])
-
+            data["packetloss_speech"] = float(regex[2][6]) * 100000
+            data["packetloss_keepalive"] = float(regex[3][7]) * 100000
+            data["packetloss_control"] = float(regex[4][8]) * 100000
+            data["packetloss_total"] = float(regex[5][9]) * 100000
+			
         except Exception as e:
             self.error(str(e))
             return None

--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -101,7 +101,7 @@ class Service(SocketService):
         self.request = "serverinfo\n"
 
         # Chart information handled by netdata.
-        self.name = "Teamspeak 3 Server"
+        #self.name = "Teamspeak 3 Server"
         self.order = ORDER
         self.definitions = CHARTS
 

--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -290,7 +290,8 @@ class Service(SocketService):
         if data.endswith("msg=ok\n\r"):
             return True
         elif "virtualserver_status=unknown" in data: 
-			self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
-			self._receive()
+            # Perform login
+            self._sock.send("login {0} {1}\n".format(self.user, self.passwd).encode())
+            self._receive()
         else:
             return False


### PR DESCRIPTION
I was unable to get the script to run, due to the startup error 
`python.d ERROR: plugin: main: job initialization: 'ts3 local' => [FAILED] (can't set attribute)`

Removing `self.name = "Teamspeak 3 Server"` solved that issue

I also noticed that packet drop was not working either and was always reporting 0 for all metrics
It seems netdata only stores integer values, and since the packet loss data is between 1 and 0, it was always reporting 0

This was solved by multiplying the data with a factor of 10^5 and then store it as an integer. It would then be scaled back down to the correct factor in the UI when being displayed

![Image of Yaktocat](https://i.imgur.com/o473yAc.png)