### PR TITLE
Correctly formatted packet loss metric to percentages

### DIFF
--- a/ts3.chart.py
+++ b/ts3.chart.py
@@ -78,10 +78,10 @@ CHARTS = {
     'packetloss': {
         'options': [None, 'Average data packet loss', 'packets loss %', 'Packet Loss', 'ts3.packetloss', 'line'],
         'lines': [
-            ['packetloss_speech', 'speech', 'absolute', 1, 100000],
-            ['packetloss_keepalive', 'keepalive', 'absolute', 1, 100000],
-            ['packetloss_control', 'control', 'absolute', 1, 100000],
-            ['packetloss_total', 'total', 'absolute', 1, 100000],
+            ['packetloss_speech', 'speech', 'absolute', 1, 1000],
+            ['packetloss_keepalive', 'keepalive', 'absolute', 1, 1000],
+            ['packetloss_control', 'control', 'absolute', 1, 1000],
+            ['packetloss_total', 'total', 'absolute', 1, 1000],
         ]
     }
 }


### PR DESCRIPTION
Turns out the TS3 API returns the packet loss as a number between 1 to 0, instead 100 to 0

![Packet loss chart](https://i.imgur.com/LMbc6Rq.png)